### PR TITLE
Handling 404 error

### DIFF
--- a/samples/adjustment.php
+++ b/samples/adjustment.php
@@ -119,6 +119,10 @@ try
         }
     }
 }
+catch(BP\InsureHubApiNotFoundException $validationException){
+    echo 'Not found';
+    echo $validationException->errorMessage();
+}
 catch(BP\InsureHubApiValidationException $validationException){
     echo 'Invalid Request';
     echo $validationException->errorMessage();

--- a/samples/cancellation.php
+++ b/samples/cancellation.php
@@ -45,6 +45,10 @@ try
         echo 'Unable to cancel sale';
     }
 }
+catch(BP\InsureHubApiNotFoundException $validationException){
+    echo 'Not found';
+    echo $validationException->errorMessage();
+}
 catch(BP\InsureHubApiValidationException $validationException){
     echo 'Invalid Request';
     echo $validationException->errorMessage();

--- a/samples/matrix.php
+++ b/samples/matrix.php
@@ -63,6 +63,10 @@ try
         }
     }
 }
+catch(BP\InsureHubApiNotFoundException $validationException){
+    echo 'Not found';
+    echo $validationException->errorMessage();
+}
 catch(BP\InsureHubApiValidationException $validationException){
     echo 'Invalid Request';
     echo $validationException->errorMessage();

--- a/samples/policy-search-by-offering-id.php
+++ b/samples/policy-search-by-offering-id.php
@@ -67,6 +67,10 @@ try
         }
     }
 }
+catch(BP\InsureHubApiNotFoundException $validationException){
+    echo 'Not found';
+    echo $validationException->errorMessage();
+}
 catch(BP\InsureHubApiValidationException $validationException){
     echo 'Invalid Request';
     echo $validationException->errorMessage();

--- a/samples/policy-search.php
+++ b/samples/policy-search.php
@@ -56,6 +56,10 @@ try
         echo 'Policy has '.count($policy->items).' policy items'.$break.$break;
     }
 }
+catch(BP\InsureHubApiNotFoundException $validationException){
+    echo 'Not found';
+    echo $validationException->errorMessage();
+}
 catch(BP\InsureHubApiValidationException $validationException){
     echo 'Invalid Request';
     echo $validationException->errorMessage();

--- a/samples/price-band.php
+++ b/samples/price-band.php
@@ -51,6 +51,10 @@ try
         echo 'Commission: '.$priceBand->commission.$break;
     }
 }
+catch(BP\InsureHubApiNotFoundException $validationException){
+    echo 'Not found';
+    echo $validationException->errorMessage();
+}
 catch(BP\InsureHubApiValidationException $validationException){
     echo 'Invalid Request';
     echo $validationException->errorMessage();

--- a/samples/quote-buy.php
+++ b/samples/quote-buy.php
@@ -102,6 +102,10 @@ try
         echo "Result failed$break";
     }
 }
+catch(BP\InsureHubApiNotFoundException $validationException){
+    echo 'Not found';
+    echo $validationException->errorMessage();
+}
 catch(BP\InsureHubApiValidationException $validationException){
     echo 'Invalid Request';
     echo $validationException->errorMessage();

--- a/src/InsureHubApiNotFoundException.php
+++ b/src/InsureHubApiNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BookingProtect\InsuranceHub\Client;
+
+
+class InsureHubApiNotFoundException extends InsureHubException {
+    public function errorMessage(): string {
+        return 'Invalid Request : '.$this->getMessage();
+    }
+}


### PR DESCRIPTION
API Client threw a generic InsureHubApiException without message in case of 404 error